### PR TITLE
#670 Fix shared library installation

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,8 @@ class LZ4Conan(ConanFile):
             else:
                 args = ["BUILD_SHARED=no", "BUILD_STATIC=yes"]
             env_build.make(args=args)
-            env_build.make(args=["PREFIX=%s" % prefix, "install"])
+            args.extend(["PREFIX=%s" % prefix, "install"])
+            env_build.make(args=args)
 
             if self.settings.os == 'Macos' and self.options.shared:
                 lib_dir = os.path.join(prefix, 'lib')


### PR DESCRIPTION
We need to add build flags when installing, otherwise both libraries are packaged.


fixes https://github.com/bincrafters/community/issues/670
fixes https://github.com/conan-io/conan/issues/4646

/cc @thekvs